### PR TITLE
Refactor permissions page

### DIFF
--- a/secret/forms.py
+++ b/secret/forms.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 
 from crispy_forms.bootstrap import PrependedAppendedText, AppendedText, FormActions
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Column, Layout, Row, Submit
+from crispy_forms.layout import Column, Field, Layout, Row, Submit
 
 from .models import Secret
 
@@ -74,8 +74,27 @@ class SecretCreateForm(SecretUpdateForm):
         self.helper.layout[-1] = FormActions(Submit("save", "Create secret"),)
 
 
-class SecretPermissionsForm(forms.Form):
+# class SecretPermissionsDeleteForm(forms.Form):
+#     user = forms.ModelChoiceField(
+#         queryset=get_user_model().objects.all().exclude(email="AnonymousUser"),
+#         required=False,
+#         widget=forms.HiddenInput(),
+#     )
+#     group = forms.ModelChoiceField(
+#         queryset=Group.objects.all().order_by("name"), required=False, widget=forms.HiddenInput(),
+#     )
+#     permission = forms.ChoiceField(choices=PERMISSION_CHOICES, widget=forms.HiddenInput(),)
+#
+#     def clean(self):
+#         cleaned_data = super().clean()
+#
+#         if not cleaned_data["user"] and not cleaned_data["group"]:
+#             raise forms.ValidationError("Select either a user or a group")
+#
+#         return cleaned_data
 
+
+class SecretPermissionsForm(forms.Form):
     user = forms.ModelChoiceField(
         queryset=get_user_model().objects.all().exclude(email="AnonymousUser"),
         required=False,
@@ -85,6 +104,20 @@ class SecretPermissionsForm(forms.Form):
         queryset=Group.objects.all().order_by("name"), required=False, widget=forms.HiddenInput(),
     )
     permission = forms.ChoiceField(choices=PERMISSION_CHOICES, widget=forms.HiddenInput(),)
+
+    def __init__(self, *args, update_permission=False, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if update_permission:
+            self.fields["permission"].widget = forms.Select()
+            self.fields["permission"].choices = PERMISSION_CHOICES
+
+            self.helper = FormHelper()
+            self.helper.form_class = "update_perms"
+            self.helper.form_show_labels = False
+            self.helper.layout = Layout(
+                "user", "group", Field("permission", css_class="form-control-sm"),
+            )
 
     def clean(self):
         cleaned_data = super().clean()

--- a/secret/tests/test_models.py
+++ b/secret/tests/test_models.py
@@ -3,6 +3,8 @@ import pytest
 from user.tests.factories import UserFactory
 from secret.tests.factories import SecretFactory
 
+from guardian.shortcuts import assign_perm, get_perms
+
 pytestmark = pytest.mark.django_db
 
 
@@ -15,3 +17,41 @@ class TestModelPermissions:
         assert user.has_perm("secret.view_secret", secret)
 
         assert user.has_perm("secret.change_secret", secret)
+
+    @pytest.mark.parametrize(
+        "start_permissions, input, expected",
+        [
+            ([], "view_secret", {"view_secret"}),
+            ([], "change_secret", {"view_secret", "change_secret"}),
+            (["view_secret"], "view_secret", {"view_secret"}),
+            (["change_secret"], "view_secret", {"view_secret"}),
+            (["change_secret"], "change_secret", {"view_secret", "change_secret"}),
+            (["change_secret", "view_secret"], "view_secret", {"view_secret"}),
+            (["change_secret", "view_secret"], "change_secret", {"change_secret", "view_secret"}),
+        ],
+    )
+    def test_permission(self, start_permissions, input, expected):
+        secret = SecretFactory()
+        user = UserFactory()
+
+        for perm in start_permissions:
+            assign_perm(perm, user, secret)
+
+        secret.set_permission(user, input)
+
+        assert set(get_perms(user, secret)) == expected
+
+    @pytest.mark.parametrize(
+        "start_permissions",
+        [["view_secret"], ["change_secret"], ["view_secret", "change_secret"], [],],
+    )
+    def test_remove_permissions(self, start_permissions):
+        secret = SecretFactory()
+        user = UserFactory()
+
+        for perm in start_permissions:
+            assign_perm(perm, user, secret)
+
+        secret.remove_permissions(user)
+
+        assert get_perms(user, secret) == []

--- a/secret/tests/test_views.py
+++ b/secret/tests/test_views.py
@@ -318,7 +318,7 @@ class TestSecretPermissionsView:
         assert audit.timestamp == timezone.now()
         assert audit.secret == secret
         assert audit.action == Actions.add_permission.name
-        assert audit.description == f"change_secret granted to {target_user}"
+        assert audit.description == f"Permission level to set change_secret for {target_user}"
 
 
 class TestSecretPermissionsDeleteView:
@@ -377,15 +377,14 @@ class TestSecretPermissionsDeleteView:
         assign_perm("view_secret", target_user, secret)
 
         response = client.post(
-            reverse("secret:delete-permission", kwargs={"pk": secret.pk}),
-            {"user": target_user.id, "permission": "view_secret"},
+            reverse("secret:delete-permission", kwargs={"pk": secret.pk}), {"user": target_user.id},
         )
 
         assert response.status_code == 302
         assert response.url == reverse("secret:permissions", kwargs={"pk": secret.id})
-        assert get_perms(target_user, secret) == ["change_secret"]
+        assert get_perms(target_user, secret) == []
 
-    def test_delete_group_permission(self, client):
+    def test_delete_group_permissions(self, client):
         user = login_and_verify_user(client)
         secret = SecretFactory()
 
@@ -397,12 +396,12 @@ class TestSecretPermissionsDeleteView:
 
         response = client.post(
             reverse("secret:delete-permission", kwargs={"pk": secret.pk}),
-            {"group": target_group.id, "permission": "view_secret"},
+            {"group": target_group.id},
         )
 
         assert response.status_code == 302
         assert response.url == reverse("secret:permissions", kwargs={"pk": secret.id})
-        assert get_perms(target_group, secret) == ["change_secret"]
+        assert get_perms(target_group, secret) == []
 
     @pytest.mark.freeze_time("2020-08-07 00:01:01")
     def test_audit_event_is_created(self, client):
@@ -428,7 +427,7 @@ class TestSecretPermissionsDeleteView:
         assert audit.user == user
         assert audit.timestamp == timezone.now()
         assert audit.secret == secret
-        assert audit.description == f"view_secret removed for {target_group}"
+        assert audit.description == f"Access removed for {target_group}"
 
 
 class TestSecretAuditView:

--- a/templates/secret/confirm-delete.html
+++ b/templates/secret/confirm-delete.html
@@ -4,17 +4,16 @@
 
 {% include 'partials/secret-nav.html' %}
 
-<h4 class="pt-3">Confirm removal</h4>
+<h4 class="pt-3">Confirm remove access</h4>
 
 <p class="pt-3">
-    Confirm the removal of the <strong>{{ permission_display }}</strong> permission for the {% if user %} <strong>{{ user }}</strong>{% else %}group <strong>{{ group }}</strong>{% endif %}
-    from the password <strong>{{ object.name }}</strong>
+    Confirm remove access to secret <strong>"{{ object.name }}"</strong> for {{ object_type }} <strong>{{ target }}</strong>?
 </p>
 
 <form method="post" action="{{ request.path }}">
     {% csrf_token %}
-    {{ form }}
-    <button type="submit" class="btn btn-danger">Remove permission</button>
+    <input type="hidden" name="{{ object_type }}" value="{{ target.id }}">
+    <button type="submit" class="btn btn-danger">Remove access</button>
 </form>
 
 {% endblock %}}

--- a/templates/secret/permissions.html
+++ b/templates/secret/permissions.html
@@ -10,30 +10,30 @@
   <thead>
     <tr>
       <th scope="col">User/Group</th>
-      <th scope="col">Permissions</th>
+      <th scope="col">Permission</th>
       <th scope="col">Remove</th>
     </tr>
   </thead>
   <tbody>
-    {% for group, perm in groups %}
+    {% for row in groups %}
     <tr>
-      <td>{{ group }}</td>
+      <td>{{ row.group }}</td>
       <td>
-          {{ perm.1 }}
+          {% crispy row.form %}
       </td>
       <td>
-          <a href="{% url 'secret:delete-permission' pk=pk %}?group={{ group.id }}&permission={{ perm.0 }}" class="badge badge-danger">Delete</a>
+          <a href="{% url 'secret:delete-permission' pk=pk %}?group={{ row.group.id }}" class="badge badge-danger">Delete</a>
       </td>
     </tr>
     {% endfor %}
-    {% for user, perm in users %}
+    {% for row in users %}
     <tr>
-      <td>{{ user }}</td>
+      <td>{{ row.user }}</td>
       <td>
-          {{ perm.1 }}
+          {% crispy row.form %}
       </td>
       <td>
-          <a href="{% url 'secret:delete-permission' pk=pk %}?user={{ user.id }}&permission={{ perm.0 }}" class="badge badge-danger">Delete</a>
+          <a href="{% url 'secret:delete-permission' pk=pk %}?user={{ row.user.id }}" class="badge badge-danger">Delete</a>
       </td>
     </tr>
     {% endfor %}
@@ -60,6 +60,10 @@
 $(document).ready(function() {
     $('#id_group,#id_user').select2({
         theme: 'bootstrap4'
+    });
+
+    $('form.update_perms select').change(function(){
+        $(this).parents("form.update_perms").submit();
     });
 });
 </script>

--- a/templates/secret/secret_list.html
+++ b/templates/secret/secret_list.html
@@ -26,7 +26,6 @@
                 </form>
             </th>
             <th scope="col" colspan="3"></th>
-            </th>
         </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
This PR changes the layout of the sharing/permissions page so that user/group permissions appear on a single row with a select box to change the the permission level.  This is more akin to the way github's permissions UI works.