### PR TITLE
Update circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             - v1-dependencies-
 
       # Add ZBAR
-      - run: sudo apt-get update && sudo apt-get install libzbar-dev  
+      - run: sudo apt-get --allow-releaseinfo-change update && sudo apt-get install libzbar-dev
 
       - run:
           name: install dependencies


### PR DESCRIPTION
The debian package repositories have had their release name changed. This allows
apt-get to ignore the release name.